### PR TITLE
[DOCS]: fix broken link to the user manual - use relative link instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Installation procedure described here makes use of the open-source package manag
 
 ##### BioPAL package installation into the created environment (users)
 
-If you are a *developer* you should not install the package: skip this part. You should refer to the section [Run the processor for developers](#-run-the-processor-for-developers). If you are a basic *user* follow this procedure. You should refer to the section [Run the processor for users](#-run-the-processor-for-users).
+If you are a *developer* you should not install the package: skip this part. You should refer to the section [Run the processor for developers](#run-the-processor-for-developers). If you are a basic *user* follow this procedure. You should refer to the section [Run the processor for users](#run-the-processor-for-users).
 
 *NOTE: the installation procedure here described is not yet working, work in progress.*
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Read carefully also contributor\'s guides before getting started.
 
 # Documentation
 
-For more details on processing configuration, refer to the initial release [user manual](https://github.com/BioPAL/BioPAL/doc/ARE-017082_BIOMASS_L2_User_Manual.pdf) version 1.1.
+For more details on processing configuration, refer to the initial release [user manual](doc/ARE-017082_BIOMASS_L2_User_Manual.pdf) version 1.1.
 
 # History
 


### PR DESCRIPTION
Hello,

The link to the user manual in README.md is currently broken and returns `404 - not found`.

This PR solves the issue by using [relative link instead](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-readmes#relative-links-and-image-paths-in-readme-files)