### PR TITLE
[ENH] TOMO FH APPs interfaces upgraded as AGB ones: input file and configuration file are now the only two inputs for each TOMO FH APP

### DIFF
--- a/biopal/__main__.py
+++ b/biopal/__main__.py
@@ -98,7 +98,7 @@ def biomassL2_processor_run(input_file_processor_xml, conf_folder=None):
     try:
 
         dataset_query_obj = dataset_query()
-        (input_file_for_stack_based, stack_composition, geographic_boundaries) = dataset_query_obj.run(input_params_obj)
+        input_file_for_stack_based = dataset_query_obj.run(input_params_obj)
 
     except Exception as e:
         logging.error(e, exc_info=True)

--- a/biopal/__main__.py
+++ b/biopal/__main__.py
@@ -116,8 +116,7 @@ def biomassL2_processor_run(input_file_xml, conf_folder=None):
         chain_obj = ForestHeight(configuration_file)
 
     if input_params_obj.L2_product == "TOMO_FH":
-        stacks_to_merge_dict = collect_stacks_to_be_merged(stack_composition) # to be deprecated
-        chain_obj = TomoForestHeight(configuration_file, stacks_to_merge_dict)
+        chain_obj = TomoForestHeight(configuration_file)
 
     if input_params_obj.L2_product == "FD":
         chain_obj = ForestDisturbance(configuration_file)

--- a/biopal/agb/main_AGB.py
+++ b/biopal/agb/main_AGB.py
@@ -137,7 +137,7 @@ class StackBasedProcessingAGB(Task):
         # dataset_query APP call if needed:
         >>>from biopal.dataset_query.dataset_query import dataset_query
         >>>dataset_query_obj = dataset_query(),
-        >>>input_file_with_stack_base_proc, _, _ = dataset_query_obj.run( input_file )
+        >>>input_file_with_stack_base_proc = dataset_query_obj.run( input_file )
         
         # StackBasedProcessingAGB APP call with the needed input sections filled:
         >>>from biopal.agb.main_AGB import StackBasedProcessingAGB
@@ -1095,7 +1095,7 @@ class CoreProcessingAGB(Task):
         # dataset_query APP call if needed:
         >>>from biopal.dataset_query.dataset_query import dataset_query
         >>>dataset_query_obj = dataset_query(),
-        >>>input_file_with_stack_base_proc, _, _ = dataset_query_obj.run( input_file )
+        >>>input_file_with_stack_base_proc = dataset_query_obj.run( input_file )
         
         # StackBasedProcessingAGB APP call if needed:
         >>>from biopal.agb.main_AGB import StackBasedProcessingAGB

--- a/biopal/dataset_query/dataset_query.py
+++ b/biopal/dataset_query/dataset_query.py
@@ -55,7 +55,7 @@ class dataset_query(Task):
     >>> input_path = BioPAL / "inputs" / "Input_File.xml"
     >>> from biopal.agb.main_AGB import dataset_query
     >>> dataset_query_obj = dataset_query()
-    >>> input_file_up_xml,_,_ = dataset_query.run( input_path )
+    >>> input_file_up_xml = dataset_query.run( input_path )
     >>> print('The Input_File has been updated with the new section "stack_based_processing" and saved to {}'.format(input_file_up_xml))
     """
 
@@ -124,7 +124,7 @@ class dataset_query(Task):
         logging.info(end_message)
         print(end_message)
         
-        return input_file_up_xml, stack_composition, geographic_boundaries
+        return input_file_up_xml
 
 
 def data_select_by_date_and_boundaries(dataset_query_obj):

--- a/biopal/io/xml_io.py
+++ b/biopal/io/xml_io.py
@@ -103,8 +103,9 @@ lut = namedtuple(
      progressive",
 )
 core_processing_fh = namedtuple("core_proc_fh", "data_equi7_fnames mask_equi7_fnames")
+core_processing_tomo_fh = namedtuple("core_proc_tomo_fh", "data_equi7_fnames mask_equi7_fnames")
 core_processing_fd = namedtuple("core_proc_fd", "dummy",)
-core_processing_tomo_fh = namedtuple("core_proc_tomo_fh", "dummy",)
+
 # main_input_params "L1c_date" sub-fields:
 L1c_date = namedtuple(
     "L1c_date_params",
@@ -293,8 +294,8 @@ def write_input_file(input_params_obj, input_file_xml):
                                   elements vary on the chain, AGB,FH,FD,TOMO_FH)
         - core_processing_agb
         - core_processing_fh
-        - core_processing_fd (place holder, to be filled in future version if needed)
-        - core_processing_tomo_fh (place holder, to be filled in future version if needed)
+        - core_processing_fd
+        - core_processing_tomo_fh
     
     Only the sections avalable into the input_params_obj structure will be written 
     to the file: not all the APPs requires all the sections. 
@@ -469,9 +470,12 @@ def write_core_processing_agb_section(father_item, core_proc_agb_obj):
     write_lut_section(core_agb_item, core_proc_agb_obj.lut_stacks, "stacks")
 
 
-def write_core_processing_fh_section(father_item, core_proc_fh_obj):
+def write_core_processing_fh_section(father_item, core_proc_fh_obj, tomo_fh_flag=False):
     
-    core_fh_item = SubElement(father_item, "core_processing_fh")
+    if tomo_fh_flag:
+        core_fh_item = SubElement(father_item, "core_processing_tomo_fh")
+    else:
+        core_fh_item = SubElement(father_item, "core_processing_fh")
 
     equi7_products_paths_item = SubElement(core_fh_item, "equi7_products_paths")
 
@@ -498,8 +502,10 @@ def write_core_processing_fd_section():
     pass
 
 
-def write_core_processing_tomo_fh_section():
-    pass
+def write_core_processing_tomo_fh_section(father_item, core_proc_fh_obj):
+   
+    # core processing section for FH and TOMO FH are the same
+    write_core_processing_fh_section(father_item, core_proc_fh_obj, tomo_fh_flag=True)
 
 
 def parse_input_file(input_file_xml):
@@ -834,9 +840,12 @@ def parse_core_proc_agb_section(root):
     return core_proc_agb_obj
 
 
-def parse_core_proc_fh_section(root):
+def parse_core_proc_fh_section(root,tomo_fh_flag=False):
 
-    core_proc_fh_item = root.find("core_processing_fh")
+    if tomo_fh_flag:
+        core_proc_fh_item = root.find("core_processing_tomo_fh")
+    else:
+        core_proc_fh_item = root.find("core_processing_fh")
 
     if core_proc_fh_item:
         equi7_products_paths_item = core_proc_fh_item.find("equi7_products_paths")
@@ -871,10 +880,9 @@ def parse_core_proc_fd_section(root):
 
 
 def parse_core_proc_tomo_fh_section(root):
-    """
-       place older function to be developed yet 
-    """
-    core_proc_tomo_fh_obj = None
+    
+    # core processing section for FH and TOMO FH are the same
+    core_proc_tomo_fh_obj = parse_core_proc_fh_section(root, tomo_fh_flag = True)
 
     return core_proc_tomo_fh_obj
 

--- a/doc/Notebooks/BioPAL_First_Tutorial.ipynb
+++ b/doc/Notebooks/BioPAL_First_Tutorial.ipynb
@@ -221,7 +221,7 @@
     "\n",
     "# Run dataset query APP\n",
     "print('Query started...')\n",
-    "input_path_from_query, _, _  = dataset_query_obj.run( input_path )\n",
+    "input_path_from_query = dataset_query_obj.run( input_path )\n",
     "\n",
     "print('The Input_File has been updated with the new section \"stack_based_processing\" and saved to {}'.format(input_path_from_query))"
    ]
@@ -981,7 +981,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.12"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Tagging @francescobanda for notification

Starting from AGB APP all the main APPs (AGB FH, FD, TOMO_FH) are to be updated in order to have simplified interfaces.
This is the upgrade of TOMO_FH APP (and relates sub APPs) interfaces.

Scientific algorithms are not changed, processing is identical after this modification.
Note: updated also one line of tutorial, due to "dataset query" output interface simplification.