### PR TITLE
Project updated to build Wheel package for PYPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 .ipynb_checkpoints/
 __pycache__
+.nox
+dist
+build
+*.egg-info
+doc/build
+.vscode

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include noxfile.py
+global-exclude __pycache__
+global-exclude *.py[co]
+exclude doc/build

--- a/README.md
+++ b/README.md
@@ -224,6 +224,20 @@ Folowing run procedure works with any installation option (with a difference in 
 	
 	Read BioPAL [tutorial](https://www.biopal.org/docs/tutorials/biopal_first_tutorial/) for other examples to insert in the script
 
+
+##### How to generate a Wheel package for pypi
+1.  Verify not to have a ".nox" folder in BioPAL/.nox, otherwise delete it.
+
+2.  From command window, with biopal environment enabled, digit:
+    pip install nox                          (if not already installed in this environment)
+    nox -s build_wheel -fb conda             (generate the wheel package; -fb conda needed only if anacondaconda is used)
+	nox -s build_sdist -fb conda             (generate the sdist package, if needed)
+	
+	The build_wheel command will produce the wheel file "BioPAL\dist\biopal-0.1-py3-none-any.whl"
+	The build_sdist command will produce the sdist (Software distribution)  file "BioPAL\dist\biopal-0.1.tar.gz"
+    
+	For pypi packages info see also https://python-packaging-tutorial.readthedocs.io/en/latest/uploading_pypi.html
+
 # Call for Contributions
 
 BioPAL is an open source project supported by a community who appreciates help from a wide range of different backgrounds. Large or small, any contribution makes a big difference; and if you\'ve never contributed to an open source project before, we hope you will start with BioPAL!

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ This repository is organized as follows:
 
 -   **inputs**: contains the XML Input File, to be set by the user before running an instance of the processing.
 
+BioPAL is already used by some ESA sponsored project, however it is still an experimental code.
+This means that there might be still bugs. If you happen to find one, make us happy by filling an issue with all the details to reproduce it the best you can.
+
+You can follow the developement roadmap to version 1.0.0 [here](https://github.com/BioPAL/BioPAL/projects/2).
+
 # Getting Started
 
 Here the required environment and dependencies are listed, as well as installation options available for now.

--- a/biopal/__init__.py
+++ b/biopal/__init__.py
@@ -2,4 +2,4 @@
 BioPAL package
 """
 
-__version__ = "0.1"
+__version__ = "0.2.0"

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,13 @@
+import nox
+
+
+@nox.session()
+def build_sdist(session: nox.Session):
+    session.install("build")
+    session.run("python", "-m", "build", "--sdist", silent=True)
+
+
+@nox.session()
+def build_wheel(session: nox.Session):
+    session.install("build")
+    session.run("python", "-m", "build", "--wheel", silent=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 120
+extend-exclude = "^/arepytools/.*"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = biopal
+url = https://biopal.org/
 description = BIOMASS Product Algorithm Laboratory
 long_description = file: README.md
 version = attr: biopal.__version__
@@ -46,6 +47,3 @@ biopal =
 [options.entry_points]
 console_scripts =
     biopal=biopal.__main__:main
-
-[sdist]
-formats = zip


### PR DESCRIPTION
Following update intrioduces the functionality to simply generate on the fly a Wheel package from the code. The usage is specified in the README.md file, explaining the command line instructions to run in order to generate the wheel and the sdist (software distribution, [python packaging tutorial](https://python-packaging-tutorial.readthedocs.io/en/latest/uploading_pypi.html) ) packages .